### PR TITLE
Update src/main/java/net/sf/hajdbc/lock/distributed/DistributedLockManag...

### DIFF
--- a/src/main/java/net/sf/hajdbc/lock/distributed/DistributedLockManager.java
+++ b/src/main/java/net/sf/hajdbc/lock/distributed/DistributedLockManager.java
@@ -170,6 +170,8 @@ public class DistributedLockManager implements LockManager, LockCommandContext, 
 				output.writeByte(descriptor.getType().ordinal());
 			}
 		}
+		
+		output.flush();
 	}
 
 	/**


### PR DESCRIPTION
...er.java

This flush is needed to ensure message is not truncated when received at other nodes. We saw there was and EOFFile Exception when tryeing to deserialize it...Thx
