### PR TITLE
Update src/main/java/net/sf/hajdbc/lock/distributed/DistributedLockManag...

### DIFF
--- a/src/main/java/net/sf/hajdbc/lock/distributed/DistributedLockManager.java
+++ b/src/main/java/net/sf/hajdbc/lock/distributed/DistributedLockManager.java
@@ -180,7 +180,7 @@ public class DistributedLockManager implements LockManager, LockCommandContext, 
 	public void readState(ObjectInput input) throws IOException, ClassNotFoundException
 	{
 		// Is this valid?  or should we unlock/clear?
-		assert this.remoteLockDescriptorMap.isEmpty();
+		//assert this.remoteLockDescriptorMap.isEmpty();
 		
 		int size = input.readInt();
 		


### PR DESCRIPTION
...er.java

this assert is always failing for us, because the remoteLockDescriptorMap  was populated during the call to 'added'
