### PR TITLE
Update src/main/java/net/sf/hajdbc/xml/XMLDatabaseClusterConfigurationFa...

### DIFF
--- a/src/main/java/net/sf/hajdbc/xml/XMLDatabaseClusterConfigurationFactory.java
+++ b/src/main/java/net/sf/hajdbc/xml/XMLDatabaseClusterConfigurationFactory.java
@@ -117,8 +117,13 @@ public class XMLDatabaseClusterConfigurationFactory<Z, D extends Database<Z>> im
 	}
 	
 	public XMLDatabaseClusterConfigurationFactory(Class<? extends DatabaseClusterConfiguration<Z, D>> targetClass, URL url)
-	{
-		this(targetClass, url.getProtocol().equals("file") ? new FileXMLStreamFactory(new File(url.getPath())) : new URLXMLStreamFactory(url));
+	{		
+		try {
+			this(targetClass, url.getProtocol().equals("file") ? new FileXMLStreamFactory(new File(url.toURI())) : new URLXMLStreamFactory(url));
+		} catch (URISyntaxException e) {
+			// This is guaranteed to success cause it comes from findresource
+			e.printStackTrace();
+		}
 	}
 	
 	public XMLDatabaseClusterConfigurationFactory(Class<? extends DatabaseClusterConfiguration<Z, D>> targetClass, XMLStreamFactory streamFactory)


### PR DESCRIPTION
...ctory.java

when in windows if the resource dir has spaces in path, it doesn´t work with  getAbsolutePath, cause file path gets double escaped and ends with %2520, instead of space. We need to do 'toURI' instead.
