### PR TITLE
Release read lock in invocation strategy

### DIFF
--- a/src/main/java/net/sf/hajdbc/sql/LocalTransactionContext.java
+++ b/src/main/java/net/sf/hajdbc/sql/LocalTransactionContext.java
@@ -97,9 +97,11 @@ public class LocalTransactionContext<Z, D extends Database<Z>> implements Transa
 				}
 				catch (Throwable e)
 				{
-					LocalTransactionContext.this.unlock();
-					
 					throw proxy.getExceptionFactory().createException(e);
+				} 
+				finally 
+				{
+					LocalTransactionContext.this.unlock();
 				}
 			}
 		};


### PR DESCRIPTION
Database activation can fail due to an unreleased read lock, the fix is to ensure the read lock is released on all paths.
