### PR TITLE
Create serializable copy of synchronization strategy set.

### DIFF
--- a/src/main/java/net/sf/hajdbc/sql/DatabaseClusterImpl.java
+++ b/src/main/java/net/sf/hajdbc/sql/DatabaseClusterImpl.java
@@ -20,6 +20,7 @@ package net.sf.hajdbc.sql;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -315,7 +316,7 @@ public class DatabaseClusterImpl<Z, D extends Database<Z>> implements DatabaseCl
 	@ManagedAttribute
 	public Set<String> getSynchronizationStrategies()
 	{
-		return this.configuration.getSynchronizationStrategyMap().keySet();
+		return new HashSet<String>(this.configuration.getSynchronizationStrategyMap().keySet());
 	}
 	
 	/**


### PR DESCRIPTION
Objects returned from managed methods should be serializable so they can be used via JMX remotely.

The key set of a HashMap is not serializable so a copy should be created.

The error that currently occurs when accessing the "synchronizationStrategies" attribute is:

```
Exception in thread "main" java.lang.reflect.UndeclaredThrowableException
    at com.sun.proxy.$Proxy0.getsynchronizationStrategies(Unknown Source)
    at HajdbcList.main(HajdbcList.java:40)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:601)
    at com.intellij.rt.execution.application.AppMain.main(AppMain.java:120)
Caused by: java.rmi.UnmarshalException: error unmarshalling return; nested exception is: 
    java.io.WriteAbortedException: writing aborted; java.io.NotSerializableException: java.util.HashMap$KeySet
    at sun.rmi.server.UnicastRef.invoke(UnicastRef.java:191)
    at com.sun.jmx.remote.internal.PRef.invoke(Unknown Source)
    at javax.management.remote.rmi.RMIConnectionImpl_Stub.getAttribute(Unknown Source)
    at javax.management.remote.rmi.RMIConnector$RemoteMBeanServerConnection.getAttribute(RMIConnector.java:901)
    at javax.management.MBeanServerInvocationHandler.invoke(MBeanServerInvocationHandler.java:280)
    ... 7 more
Caused by: java.io.WriteAbortedException: writing aborted; java.io.NotSerializableException: java.util.HashMap$KeySet
    at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1351)
    at java.io.ObjectInputStream.readObject(ObjectInputStream.java:369)
    at sun.rmi.server.UnicastRef.unmarshalValue(UnicastRef.java:324)
    at sun.rmi.server.UnicastRef.invoke(UnicastRef.java:173)
    ... 11 more
Caused by: java.io.NotSerializableException: java.util.HashMap$KeySet
    at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1180)
    at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:346)
    at sun.rmi.server.UnicastRef.marshalValue(UnicastRef.java:292)
    at sun.rmi.server.UnicastServerRef.dispatch(UnicastServerRef.java:332)
    at sun.rmi.transport.Transport$1.run(Transport.java:177)
    at sun.rmi.transport.Transport$1.run(Transport.java:174)
    at java.security.AccessController.doPrivileged(Native Method)
    at sun.rmi.transport.Transport.serviceCall(Transport.java:173)
    at sun.rmi.transport.tcp.TCPTransport.handleMessages(TCPTransport.java:553)
    at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(TCPTransport.java:808)
    at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(TCPTransport.java:667)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
    at java.lang.Thread.run(Thread.java:722)
```
