### PR TITLE
Update SQL:2003 keyword list to include only *reserved* keywords.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,10 +228,9 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-release-plugin</artifactId>
-				<!-- See MRELEASE-691 -->
-				<!--configuration>
+				<configuration>
 					<tagNameFormat>${project.version}</tagNameFormat>
-				</configuration-->
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>

--- a/src/main/java/net/sf/hajdbc/dialect/StandardIdentifierNormalizer.java
+++ b/src/main/java/net/sf/hajdbc/dialect/StandardIdentifierNormalizer.java
@@ -19,49 +19,18 @@ package net.sf.hajdbc.dialect;
 
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
 
 import net.sf.hajdbc.IdentifierNormalizer;
-import net.sf.hajdbc.util.Strings;
 
 public class StandardIdentifierNormalizer implements IdentifierNormalizer
 {
-	// As defined in SQL-92 specification: http://www.andrew.cmu.edu/user/shadow/sql/sql1992.txt
-	private static final String[] SQL_92_RESERVED_WORDS = new String[] {
-		"ABSOLUTE", "ACTION", "ADD", "ALL", "ALLOCATE", "ALTER", "AND", "ANY", "ARE", "AS", "ASC", "ASSERTION", "AT", "AUTHORIZATION", "AVG",
-		"BEGIN", "BETWEEN", "BIT", "BIT_LENGTH", "BOTH", "BY",
-		"CASCADE", "CASCADED", "CASE", "CAST", "CATALOG", "CHAR", "CHARACTER", "CHAR_LENGTH", "CHARACTER_LENGTH", "CHECK", "CLOSE", "COALESCE", "COLLATE", "COLLATION", "COLUMN", "COMMIT", "CONNECT", "CONNECTION", "CONSTRAINT", "CONSTRAINTS", "CONTINUE", "CONVERT", "CORRESPONDING", "COUNT", "CREATE", "CROSS", "CURRENT", "CURRENT_DATE", "CURRENT_TIME", "CURRENT_TIMESTAMP", "CURRENT_USER", "CURSOR",
-		"DATE", "DAY", "DEALLOCATE", "DEC", "DECIMAL", "DECLARE", "DEFAULT", "DEFERRABLE", "DEFERRED", "DELETE", "DESC", "DESCRIBE", "DESCRIPTOR", "DIAGNOSTICS", "DISCONNECT", "DISTINCT", "DOMAIN", "DOUBLE", "DROP",
-		"ELSE", "END", "END-EXEC", "ESCAPE", "EXCEPT", "EXCEPTION", "EXEC", "EXECUTE", "EXISTS", "EXTERNAL", "EXTRACT",
-		"FALSE", "FETCH", "FIRST", "FLOAT", "FOR", "FOREIGN", "FOUND", "FROM", "FULL",
-		"GET", "GLOBAL", "GO", "GOTO", "GRANT", "GROUP",
-		"HAVING", "HOUR",
-		"IDENTITY", "IMMEDIATE", "IN", "INDICATOR", "INITIALLY", "INNER", "INPUT", "INSENSITIVE", "INSERT", "INT", "INTEGER", "INTERSECT", "INTERVAL", "INTO", "IS", "ISOLATION",
-		"JOIN",
-		"KEY",
-		"LANGUAGE", "LAST", "LEADING", "LEFT", "LEVEL", "LIKE", "LOCAL", "LOWER",
-		"MATCH", "MAX", "MIN", "MINUTE", "MODULE", "MONTH",
-		"NAMES", "NATIONAL", "NATURAL", "NCHAR", "NEXT", "NO", "NOT", "NULL", "NULLIF", "NUMERIC",
-		"OCTET_LENGTH", "OF", "ON", "ONLY", "OPEN", "OPTION", "OR", "ORDER", "OUTER", "OUTPUT", "OVERLAPS",
-		"PAD", "PARTIAL", "POSITION", "PRECISION", "PREPARE", "PRESERVE", "PRIMARY", "PRIOR", "PRIVILEGES", "PROCEDURE", "PUBLIC",
-		"READ", "REAL", "REFERENCES", "RELATIVE", "RESTRICT", "REVOKE", "RIGHT", "ROLLBACK", "ROWS",
-		"SCHEMA", "SCROLL", "SECOND", "SECTION", "SELECT", "SESSION", "SESSION_USER", "SET", "SIZE", "SMALLINT", "SOME", "SPACE", "SQL", "SQLCODE", "SQLERROR", "SQLSTATE", "SUBSTRING", "SUM", "SYSTEM_USER",
-		"TABLE", "TEMPORARY", "THEN", "TIME", "TIMESTAMP", "TIMEZONE_HOUR", "TIMEZONE_MINUTE", "TO", "TRAILING", "TRANSACTION", "TRANSLATE", "TRANSLATION", "TRIM", "TRUE",
-		"UNION", "UNIQUE", "UNKNOWN", "UPDATE", "UPPER", "USAGE", "USER", "USING",
-		"VALUE", "VALUES", "VARCHAR", "VARYING", "VIEW",
-		"WHEN", "WHENEVER", "WHERE", "WITH", "WORK", "WRITE",
-		"YEAR",
-		"ZONE"
-	};
-	
 	private static final Pattern UPPER_CASE_PATTERN = Pattern.compile("[A-Z]");
 	private static final Pattern LOWER_CASE_PATTERN = Pattern.compile("[a-z]");
 	
-	private final Set<String> reservedIdentifierSet = new HashSet<String>(SQL_92_RESERVED_WORDS.length);
 	private final Pattern identifierPattern;
+	private final Set<String> reservedIdentifiers;
 	private final String quote;
 	private final boolean supportsMixedCaseIdentifiers;
 	private final boolean supportsMixedCaseQuotedIdentifiers;
@@ -70,9 +39,10 @@ public class StandardIdentifierNormalizer implements IdentifierNormalizer
 	private final boolean storesUpperCaseIdentifiers;
 	private final boolean storesUpperCaseQuotedIdentifiers;
 	
-	public StandardIdentifierNormalizer(DatabaseMetaData metaData, Pattern identifierPattern) throws SQLException
+	public StandardIdentifierNormalizer(DatabaseMetaData metaData, Pattern identifierPattern, Set<String> reservedIdentifiers) throws SQLException
 	{
 		this.identifierPattern = identifierPattern;
+		this.reservedIdentifiers = reservedIdentifiers;
 		this.quote = metaData.getIdentifierQuoteString();
 		this.supportsMixedCaseIdentifiers = metaData.supportsMixedCaseIdentifiers();
 		this.supportsMixedCaseQuotedIdentifiers = metaData.supportsMixedCaseQuotedIdentifiers();
@@ -80,13 +50,6 @@ public class StandardIdentifierNormalizer implements IdentifierNormalizer
 		this.storesLowerCaseQuotedIdentifiers = metaData.storesLowerCaseQuotedIdentifiers();
 		this.storesUpperCaseIdentifiers = metaData.storesUpperCaseIdentifiers();
 		this.storesUpperCaseQuotedIdentifiers = metaData.storesUpperCaseQuotedIdentifiers();
-		
-		this.reservedIdentifierSet.addAll(Arrays.asList(SQL_92_RESERVED_WORDS));
-		
-		for (String word: metaData.getSQLKeywords().split(Strings.COMMA))
-		{
-			this.reservedIdentifierSet.add(word.toUpperCase());
-		}
 	}
 
 	@Override
@@ -101,7 +64,7 @@ public class StandardIdentifierNormalizer implements IdentifierNormalizer
 		String raw = quoted ? identifier.substring(quoteLength, identifier.length() - quoteLength) : identifier;
 		
 		// Quote reserved identifiers
-		boolean requiresQuoting = this.reservedIdentifierSet.contains(raw.toUpperCase());
+		boolean requiresQuoting = this.reservedIdentifiers.contains(raw.toUpperCase());
 		
 		// Quote identifiers containing special characters
 		requiresQuoting |= !this.identifierPattern.matcher(raw).matches();

--- a/src/main/java/net/sf/hajdbc/dialect/mysql/MySQLDialect.java
+++ b/src/main/java/net/sf/hajdbc/dialect/mysql/MySQLDialect.java
@@ -20,8 +20,11 @@ package net.sf.hajdbc.dialect.mysql;
 import java.io.File;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import net.sf.hajdbc.ConnectionProperties;
 import net.sf.hajdbc.DumpRestoreSupport;
@@ -35,6 +38,34 @@ import net.sf.hajdbc.util.Strings;
 @SuppressWarnings("nls")
 public class MySQLDialect extends StandardDialect implements DumpRestoreSupport
 {
+	// Taken from: http://dev.mysql.com/doc/refman/5.7/en/reserved-words.html
+	protected static final String[] RESERVED_KEY_WORDS = new String[] {
+		"ACCESSIBLE", "ADD", "ALL", "ALTER", "ANALYZE", "AND", "AS", "ASC", "ASENSITIVE",
+		"BEFORE", "BETWEEN", "BIGINT", "BINARY", "BLOB", "BOTH", "BY",
+		"CALL", "CASCADE", "CASE", "CHANGE", "CHAR", "CHARACTER", "CHECK", "COLLATE", "COLUMN", "CONDITION", "CONSTRAINT", "CONTINUE", "CONVERT", "CREATE", "CROSS", "CURRENT_DATE", "CURRENT_TIME", "CURRENT_TIMESTAMP", "CURRENT_USER", "CURSOR",
+		"DATABASE", "DATABASES", "DAY_HOUR", "DAY_MICROSECOND", "DAY_MINUTE", "DAY_SECOND", "DEC", "DECIMAL", "DECLARE", "DEFAULT", "DELAYED", "DELETE", "DESC", "DESCRIBE", "DETERMINISTIC", "DISTINCT", "DISTINCTROW", "DIV", "DOUBLE", "DROP", "DUAL",
+		"EACH", "ELSE", "ELSEIF", "ENCLOSED", "ESCAPED", "EXISTS", "EXIT", "EXPLAIN",
+		"FALSE", "FETCH", "FLOAT", "FLOAT4", "FLOAT8", "FOR", "FORCE", "FOREIGN", "FROM", "FULLTEXT",
+		"GET", "GRANT", "GROUP",
+		"HAVING", "HIGH_PRIORITY", "HOUR_MICROSECOND", "HOUR_MINUTE", "HOUR_SECOND",
+		"IF", "IGNORE", "IN", "INDEX", "INFILE", "INNER", "INOUT", "INSENSITIVE", "INSERT", "INT", "INT1", "INT2", "INT3", "INT4", "INT8", "INTEGER", "INTERVAL", "INTO", "IO_AFTER_GTIDS", "IO_BEFORE_GTIDS", "IS", "ITERATE",
+		"JOIN",
+		"KEY", "KEYS", "KILL",
+		"LEADING", "LEAVE", "LEFT", "LIKE", "LIMIT", "LINEAR", "LINES", "LOAD", "LOCALTIME", "LOCALTIMESTAMP", "LOCK", "LONG", "LONGBLOB", "LONGTEXT", "LOOP", "LOW_PRIORITY",
+		"MASTER_BIND", "MASTER_SSL_VERIFY_SERVER_CERT", "MATCH", "MAXVALUE", "MEDIUMBLOB", "MEDIUMINT", "MEDIUMTEXT", "MIDDLEINT", "MINUTE_MICROSECOND", "MINUTE_SECOND", "MOD", "MODIFIES",
+		"NATURAL", "NONBLOCKING", "NOT", "NO_WRITE_TO_BINLOG", "NULL", "NUMERIC",
+		"ON", "OPTIMIZE", "OPTION", "OPTIONALLY", "OR", "ORDER", "OUT", "OUTER", "OUTFILE",
+		"PARTITION", "PRECISION", "PRIMARY", "PROCEDURE", "PURGE",
+		"RANGE", "READ", "READS", "READ_WRITE", "REAL", "REFERENCES", "REGEXP", "RELEASE", "RENAME", "REPEAT", "REPLACE", "REQUIRE", "RESIGNAL", "RESTRICT", "RETURN", "REVOKE", "RIGHT", "RLIKE",
+		"SCHEMA", "SCHEMAS", "SECOND_MICROSECOND", "SELECT", "SENSITIVE", "SEPARATOR", "SET", "SHOW", "SIGNAL", "SMALLINT", "SPATIAL", "SPECIFIC", "SQL", "SQLEXCEPTION", "SQLSTATE", "SQLWARNING", "SQL_BIG_RESULT", "SQL_CALC_FOUND_ROWS", "SQL_SMALL_RESULT", "SSL", "STARTING", "STRAIGHT_JOIN",
+		"TABLE", "TERMINATED", "THEN", "TINYBLOB", "TINYINT", "TINYTEXT", "TO", "TRAILING", "TRIGGER", "TRUE",
+		"UNDO", "UNION", "UNIQUE", "UNLOCK", "UNSIGNED", "UPDATE", "USAGE", "USE", "USING", "UTC_DATE", "UTC_TIME", "UTC_TIMESTAMP",
+		"VALUES", "VARBINARY", "VARCHAR", "VARCHARACTER", "VARYING",
+		"WHEN", "WHERE", "WHILE", "WITH", "WRITE",
+		"XOR",
+		"YEAR_MONTH",
+		"ZEROFILL",
+	};
 	private static final File PASSWORD_FILE = new File(String.format("%s%s.my.cnf", Strings.USER_HOME, Strings.FILE_SEPARATOR));
 	
 	/**
@@ -45,6 +76,12 @@ public class MySQLDialect extends StandardDialect implements DumpRestoreSupport
 	protected String vendorPattern()
 	{
 		return "mysql";
+	}
+
+	@Override
+	protected Set<String> reservedIdentifiers(DatabaseMetaData metaData)
+	{
+		return new HashSet<String>(Arrays.asList(RESERVED_KEY_WORDS));
 	}
 
 	/**


### PR DESCRIPTION
Make it easier for dialects to override reserved keywords and identifier patterns used to create a StandardIdentifierNormalizer.
Add reserved keywords overrides for PostgreSQL and MySQL dialects..
