### PR TITLE
Fix input channel registration

### DIFF
--- a/src/main/java/net/sf/hajdbc/io/InputSinkRegistryImpl.java
+++ b/src/main/java/net/sf/hajdbc/io/InputSinkRegistryImpl.java
@@ -45,7 +45,7 @@ public class InputSinkRegistryImpl<S> implements InputSinkRegistry<S>
 	
 	private <I> void addInputChannel(Class<I> inputClass, InputSinkChannel<I, S> channel)
 	{
-		this.channels.put(InputStream.class, channel);
+		this.channels.put(inputClass, channel);
 	}
 	
 	S addInputSink(S sink)


### PR DESCRIPTION
The input sink registry implementation was incorrectly keying channels resulting in a failure to correctly proxy the setCharacterStream method of PreparedStatement. This resulted in columns in some databases being updated but not others (only one database would get the value, others would be empty)
