### PR TITLE
Add option to clean postgres DB when restoring

### DIFF
--- a/src/main/java/net/sf/hajdbc/dialect/postgresql/PostgreSQLDialect.java
+++ b/src/main/java/net/sf/hajdbc/dialect/postgresql/PostgreSQLDialect.java
@@ -258,7 +258,7 @@ public class PostgreSQLDialect extends StandardDialect implements DumpRestoreSup
 	@Override
 	public ProcessBuilder createRestoreProcess(ConnectionProperties properties, File file)
 	{
-		return setPassword(new ProcessBuilder("pg_restore", "-h", properties.getHost(), "-p", properties.getPort(), "-U", properties.getUser(), "-d", properties.getDatabase(), file.getPath()), properties);
+		return setPassword(new ProcessBuilder("pg_restore", "-h", properties.getHost(), "-p", properties.getPort(), "-U", properties.getUser(), "-d", properties.getDatabase(), "-c", file.getPath()), properties);
 	}
 	
 	private static ProcessBuilder setPassword(ProcessBuilder builder, ConnectionProperties properties)


### PR DESCRIPTION
Without the "-c" option database restore can fail if there is an existing schema.

'Clean (drop) database objects before recreating them. (This might
generate some harmless error messages, if any objects were not present
in the destination database.)'

http://www.postgresql.org/docs/9.2/static/app-pgrestore.html
