### PR TITLE
Enable caching of CommonDataSource reference within CommonDataSourceDatabase

### DIFF
--- a/src/main/java/net/sf/hajdbc/Database.java
+++ b/src/main/java/net/sf/hajdbc/Database.java
@@ -64,17 +64,18 @@ public interface Database<Z> extends Comparable<Database<Z>>
 	/**
 	 * Connects to the database using the specified connection factory.
 	 * @param connectionSource a factory object for creating connections
+	 * @param password a decoded password
 	 * @return a database connection
 	 * @throws SQLException if connection fails
 	 */
 	Connection connect(Z connectionSource, String password) throws SQLException;
 	
 	/**
-	 * Factory method for creating a connection factory object for this database.
-	 * @return a connection factory object
-	 * @throws IllegalArgumentException if connection factory could not be created
+	 * Returns a connection source for this database.
+	 * @return a connection source
+	 * @throws IllegalArgumentException if connection source could not be created
 	 */
-	Z createConnectionSource();
+	Z getConnectionSource();
 	
 	boolean isDirty();
 	

--- a/src/main/java/net/sf/hajdbc/DatabaseCluster.java
+++ b/src/main/java/net/sf/hajdbc/DatabaseCluster.java
@@ -78,24 +78,6 @@ public interface DatabaseCluster<Z, D extends Database<Z>> extends Lifecycle
 	ExecutorService getExecutor();
 	
 	/**
-	 * Returns an executor service used to execute end transaction statements.
-	 * @return an implementation of <code>ExecutorService</code>
-	 */
-//	ExecutorService getEndTransactionExecutor();
-	
-	/**
-	 * Returns an executor service used to execute transactional database writes.
-	 * @return an implementation of <code>ExecutorService</code>
-	 */
-//	ExecutorService getTransactionalExecutor();
-	
-	/**
-	 * Returns an executor service used to execute non-transactional database writes.
-	 * @return an implementation of <code>ExecutorService</code>
-	 */
-//	ExecutorService getNonTransactionalExecutor();
-	
-	/**
 	 * Returns a dialect capable of returning database vendor specific values.
 	 * @return an implementation of <code>Dialect</code>
 	 */

--- a/src/main/java/net/sf/hajdbc/cache/eager/EagerDatabaseMetaDataCache.java
+++ b/src/main/java/net/sf/hajdbc/cache/eager/EagerDatabaseMetaDataCache.java
@@ -55,7 +55,7 @@ public class EagerDatabaseMetaDataCache<Z, D extends Database<Z>> implements Dat
 		
 		for (D database: this.cluster.getBalancer())
 		{
-			Connection connection = database.connect(database.createConnectionSource(), database.decodePassword(this.cluster.getDecoder()));
+			Connection connection = database.connect(database.getConnectionSource(), database.decodePassword(this.cluster.getDecoder()));
 			
 			try
 			{

--- a/src/main/java/net/sf/hajdbc/cache/eager/SharedEagerDatabaseMetaDataCache.java
+++ b/src/main/java/net/sf/hajdbc/cache/eager/SharedEagerDatabaseMetaDataCache.java
@@ -59,7 +59,7 @@ public class SharedEagerDatabaseMetaDataCache<Z, D extends Database<Z>> implemen
 			throw new SQLException(Messages.NO_ACTIVE_DATABASES.getMessage());
 		}
 		
-		this.setDatabaseProperties(database.connect(database.createConnectionSource(), database.decodePassword(this.cluster.getDecoder())));
+		this.setDatabaseProperties(database.connect(database.getConnectionSource(), database.decodePassword(this.cluster.getDecoder())));
 	}
 
 	/**

--- a/src/main/java/net/sf/hajdbc/sql/AbstractRootProxyFactory.java
+++ b/src/main/java/net/sf/hajdbc/sql/AbstractRootProxyFactory.java
@@ -57,7 +57,7 @@ public abstract class AbstractRootProxyFactory<Z, D extends Database<Z>> extends
 	@Override
 	protected Z create(D database)
 	{
-		return database.createConnectionSource();
+		return database.getConnectionSource();
 	}
 
 	@Override

--- a/src/main/java/net/sf/hajdbc/sql/DatabaseClusterImpl.java
+++ b/src/main/java/net/sf/hajdbc/sql/DatabaseClusterImpl.java
@@ -832,7 +832,7 @@ public class DatabaseClusterImpl<Z, D extends Database<Z>> implements DatabaseCl
 	{
 		try
 		{
-			Connection connection = database.connect(database.createConnectionSource(), database.decodePassword(this.decoder));
+			Connection connection = database.connect(database.getConnectionSource(), database.decodePassword(this.decoder));
 			try
 			{
 				return this.dialect.isValid(connection);

--- a/src/main/java/net/sf/hajdbc/sql/DriverDatabase.java
+++ b/src/main/java/net/sf/hajdbc/sql/DriverDatabase.java
@@ -85,10 +85,10 @@ public class DriverDatabase extends AbstractDatabase<Driver>
 	}
 
 	/**
-	 * @see net.sf.hajdbc.Database#createConnectionSource()
+	 * @see net.sf.hajdbc.Database#getConnectionSource()
 	 */
 	@Override
-	public Driver createConnectionSource()
+	public Driver getConnectionSource()
 	{
 		return getDriver(this.getLocation());
 	}

--- a/src/main/java/net/sf/hajdbc/state/sql/SQLStateManager.java
+++ b/src/main/java/net/sf/hajdbc/state/sql/SQLStateManager.java
@@ -572,7 +572,7 @@ public class SQLStateManager<Z, D extends Database<Z>> implements StateManager, 
 	@Override
 	public void start() throws Exception
 	{
-		this.driver = this.database.createConnectionSource();
+		this.driver = this.database.getConnectionSource();
 		this.password = this.database.decodePassword(this.cluster.getDecoder());
 		this.pool = this.poolFactory.createPool(new ConnectionPoolProvider(this));
 		

--- a/src/main/java/net/sf/hajdbc/sync/SynchronizationContextImpl.java
+++ b/src/main/java/net/sf/hajdbc/sync/SynchronizationContextImpl.java
@@ -88,7 +88,7 @@ public class SynchronizationContextImpl<Z, D extends Database<Z>> implements Syn
 		
 		if (entry == null)
 		{
-			Connection connection = database.connect(database.createConnectionSource(), database.decodePassword(this.cluster.getDecoder()));
+			Connection connection = database.connect(database.getConnectionSource(), database.decodePassword(this.cluster.getDecoder()));
 			entry = new AbstractMap.SimpleImmutableEntry<Connection, Boolean>(connection, connection.getAutoCommit());
 			
 			this.connectionMap.put(database, entry);

--- a/src/test/java/net/sf/hajdbc/MockDatabase.java
+++ b/src/test/java/net/sf/hajdbc/MockDatabase.java
@@ -57,10 +57,10 @@ public class MockDatabase extends AbstractDatabase<Void>
 
 	/**
 	 * {@inheritDoc}
-	 * @see net.sf.hajdbc.Database#createConnectionSource()
+	 * @see net.sf.hajdbc.Database#getConnectionSource()
 	 */
 	@Override
-	public Void createConnectionSource()
+	public Void getConnectionSource()
 	{
 		return null;
 	}

--- a/src/test/java/net/sf/hajdbc/balancer/AbstractBalancerTest.java
+++ b/src/test/java/net/sf/hajdbc/balancer/AbstractBalancerTest.java
@@ -417,7 +417,6 @@ public abstract class AbstractBalancerTest
 		when(invoker.invoke(this.databases[0], object)).thenThrow(expectedException);
 		
 		result = null;
-		exception = null;
 		
 		try
 		{


### PR DESCRIPTION
Fixes issue where DataSource is created multiple times, which is very bad if the DataSource encapsulates a connection pool.
