### PR TITLE
equals(Object obj)" and "hashCode()" should be overridden in pairs

### DIFF
--- a/core/src/main/java/net/sf/hajdbc/durability/DurabilityEventImpl.java
+++ b/core/src/main/java/net/sf/hajdbc/durability/DurabilityEventImpl.java
@@ -74,4 +74,11 @@ public class DurabilityEventImpl extends Event<Object> implements DurabilityEven
 		
 		return (this.phase == event.getPhase()) && this.getTransactionId().equals(event.getTransactionId());
 	}
+
+	@Override
+	public int hashCode() {
+		int result = super.hashCode();
+		result = 31 * result + (this.phase != null ? this.phase.hashCode() : 0);
+		return result;
+	}
 }

--- a/core/src/main/java/net/sf/hajdbc/durability/InvokerEventImpl.java
+++ b/core/src/main/java/net/sf/hajdbc/durability/InvokerEventImpl.java
@@ -89,4 +89,12 @@ public class InvokerEventImpl extends DurabilityEventImpl implements InvokerEven
 		
 		return super.equals(object) && this.databaseId.equals(event.getDatabaseId());
 	}
+
+	@Override
+	public int hashCode() {
+		int result1 = super.hashCode();
+		result1 = 31 * result1 + (this.databaseId != null ? this.databaseId.hashCode() : 0);
+		result1 = 31 * result1 + (this.result != null ? this.result.hashCode() : 0);
+		return result1;
+	}
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1206 - “equals(Object obj)" and "hashCode()" should be overridden in pairs ”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1206
Please let me know if you have any questions.
Ayman Abdelghany.