### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/core/src/main/java/net/sf/hajdbc/util/Files.java
+++ b/core/src/main/java/net/sf/hajdbc/util/Files.java
@@ -25,7 +25,10 @@ import java.security.PrivilegedExceptionAction;
 public class Files
 {
 	public static String TEMP_FILE_PREFIX = "ha-jdbc_";
-	
+
+	private Files() {
+	}
+
 	public static File createTempFile(final String suffix) throws IOException
 	{
 		PrivilegedExceptionAction<File> action = new PrivilegedExceptionAction<File>()


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.