### PR TITLE
Using Collection.isEmpty() to test for emptiness

### DIFF
--- a/core/src/main/java/net/sf/hajdbc/util/concurrent/cron/CronExpression.java
+++ b/core/src/main/java/net/sf/hajdbc/util/concurrent/cron/CronExpression.java
@@ -1186,7 +1186,7 @@ public final class CronExpression implements Serializable, Cloneable {
 
             // get second.................................................
             st = seconds.tailSet(sec);
-            if (st != null && st.size() != 0) {
+            if (st != null && !st.isEmpty()) {
                 sec = st.first();
             } else {
                 sec = seconds.first();
@@ -1201,7 +1201,7 @@ public final class CronExpression implements Serializable, Cloneable {
 
             // get minute.................................................
             st = minutes.tailSet(min);
-            if (st != null && st.size() != 0) {
+            if (st != null && !st.isEmpty()) {
                 t = min;
                 min = st.first();
             } else {
@@ -1222,7 +1222,7 @@ public final class CronExpression implements Serializable, Cloneable {
 
             // get hour...................................................
             st = hours.tailSet(hr);
-            if (st != null && st.size() != 0) {
+            if (st != null && !st.isEmpty()) {
                 t = hr;
                 hr = st.first();
             } else {
@@ -1337,7 +1337,7 @@ public final class CronExpression implements Serializable, Cloneable {
                         day = daysOfMonth.first();
                         mon++;
                     }
-                } else if (st != null && st.size() != 0) {
+                } else if (st != null && !st.isEmpty()) {
                     t = day;
                     day = st.first();
                     // make sure we don't over-run a short month, such as february
@@ -1454,7 +1454,7 @@ public final class CronExpression implements Serializable, Cloneable {
                     int dow = daysOfWeek.first(); // desired
                     // d-o-w
                     st = daysOfWeek.tailSet(cDow);
-                    if (st != null && st.size() > 0) {
+                    if (st != null && !st.isEmpty()) {
                         dow = st.first();
                     }
 
@@ -1508,7 +1508,7 @@ public final class CronExpression implements Serializable, Cloneable {
 
             // get month...................................................
             st = months.tailSet(mon);
-            if (st != null && st.size() != 0) {
+            if (st != null && !st.isEmpty()) {
                 t = mon;
                 mon = st.first();
             } else {
@@ -1535,7 +1535,7 @@ public final class CronExpression implements Serializable, Cloneable {
 
             // get year...................................................
             st = years.tailSet(year);
-            if (st != null && st.size() != 0) {
+            if (st != null && !st.isEmpty()) {
                 t = year;
                 year = st.first();
             } else {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155 - “Collection.isEmpty() should be used to test for emptiness”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1155
Please let me know if you have any questions.
Ayman Abdelghany.