### PR TITLE
A field should not duplicate the name of its class

### DIFF
--- a/core/src/main/java/net/sf/hajdbc/Version.java
+++ b/core/src/main/java/net/sf/hajdbc/Version.java
@@ -29,14 +29,14 @@ public class Version
 {
 	public static final Version CURRENT = new Version(ResourceBundle.getBundle(Version.class.getName()).getString("version"));
 	
-	private final String version;
+	private final String versionField;
 	private final int major;
 	private final int minor;
 	private final int revision;
 	
 	Version(String version)
 	{
-		this.version = version;
+		this.versionField = version;
 		this.major = parse(0);
 		this.minor = parse(1);
 		this.revision = parse(2);
@@ -44,7 +44,7 @@ public class Version
 	
 	private int parse(int index)
 	{
-		return Integer.parseInt(this.version.split(Pattern.quote(Strings.DASH))[0].split(Pattern.quote(Strings.DOT))[index]);
+		return Integer.parseInt(this.versionField.split(Pattern.quote(Strings.DASH))[0].split(Pattern.quote(Strings.DOT))[index]);
 	}
 	
 	public int getMajor()
@@ -65,6 +65,6 @@ public class Version
 	@Override
 	public String toString()
 	{
-		return this.version;
+		return this.versionField;
 	}
 }

--- a/core/src/main/java/net/sf/hajdbc/lock/semaphore/SemaphoreLockManager.java
+++ b/core/src/main/java/net/sf/hajdbc/lock/semaphore/SemaphoreLockManager.java
@@ -87,26 +87,26 @@ public class SemaphoreLockManager implements LockManager
 	
 	private static class GlobalLock implements Lock
 	{
-		private Lock globalLock;
+		private Lock globalLockField;
 		private Lock lock;
 		
 		GlobalLock(Lock globalLock, Lock lock)
 		{
-			this.globalLock = globalLock;
+			this.globalLockField = globalLock;
 			this.lock = lock;
 		}
 		
 		@Override
 		public void lock()
 		{
-			this.globalLock.lock();
+			this.globalLockField.lock();
 			this.lock.lock();
 		}
 
 		@Override
 		public void lockInterruptibly() throws InterruptedException
 		{
-			this.globalLock.lockInterruptibly();
+			this.globalLockField.lockInterruptibly();
 			
 			try
 			{
@@ -114,7 +114,7 @@ public class SemaphoreLockManager implements LockManager
 			}
 			catch (InterruptedException e)
 			{
-				this.globalLock.unlock();
+				this.globalLockField.unlock();
 				throw e;
 			}
 		}
@@ -122,14 +122,14 @@ public class SemaphoreLockManager implements LockManager
 		@Override
 		public boolean tryLock()
 		{
-			if (this.globalLock.tryLock())
+			if (this.globalLockField.tryLock())
 			{
 				if (this.lock.tryLock())
 				{
 					return true;
 				}
 
-				this.globalLock.unlock();
+				this.globalLockField.unlock();
 			}
 
 			return false;
@@ -138,14 +138,14 @@ public class SemaphoreLockManager implements LockManager
 		@Override
 		public boolean tryLock(long time, TimeUnit unit) throws InterruptedException
 		{
-			if (this.globalLock.tryLock(time, unit))
+			if (this.globalLockField.tryLock(time, unit))
 			{
 				if (this.lock.tryLock(time, unit))
 				{
 					return true;
 				}
 
-				this.globalLock.unlock();
+				this.globalLockField.unlock();
 			}
 
 			return false;
@@ -155,7 +155,7 @@ public class SemaphoreLockManager implements LockManager
 		public void unlock()
 		{
 			this.lock.unlock();
-			this.globalLock.unlock();
+			this.globalLockField.unlock();
 		}
 
 		@Override

--- a/core/src/main/java/net/sf/hajdbc/util/concurrent/cron/CronExpression.java
+++ b/core/src/main/java/net/sf/hajdbc/util/concurrent/cron/CronExpression.java
@@ -237,7 +237,7 @@ public final class CronExpression implements Serializable, Cloneable {
         dayMap.put("SAT", 7);
     }
 
-    private final String cronExpression;
+    private final String cronExpressionField;
     private TimeZone timeZone = null;
     protected transient TreeSet<Integer> seconds;
     protected transient TreeSet<Integer> minutes;
@@ -271,9 +271,9 @@ public final class CronExpression implements Serializable, Cloneable {
             throw new IllegalArgumentException("cronExpression cannot be null");
         }
         
-        this.cronExpression = cronExpression.toUpperCase(Locale.US);
+        this.cronExpressionField = cronExpression.toUpperCase(Locale.US);
         
-        buildExpression(this.cronExpression);
+        buildExpression(this.cronExpressionField);
     }
     
     /**
@@ -289,9 +289,9 @@ public final class CronExpression implements Serializable, Cloneable {
          * ParseException. We also elide some of the sanity checking as it is
          * not logically trippable.
          */
-        this.cronExpression = expression.getCronExpression();
+        this.cronExpressionField = expression.getCronExpression();
         try {
-            buildExpression(cronExpression);
+            buildExpression(cronExpressionField);
         } catch (ParseException ex) {
             throw new AssertionError();
         }
@@ -400,7 +400,7 @@ public final class CronExpression implements Serializable, Cloneable {
      */
     @Override
     public String toString() {
-        return cronExpression;
+        return cronExpressionField;
     }
 
     /**
@@ -842,7 +842,7 @@ public final class CronExpression implements Serializable, Cloneable {
     }
 
     public String getCronExpression() {
-        return cronExpression;
+        return cronExpressionField;
     }
     
     public String getExpressionSummary() {
@@ -1636,7 +1636,7 @@ public final class CronExpression implements Serializable, Cloneable {
         
         stream.defaultReadObject();
         try {
-            buildExpression(cronExpression);
+            buildExpression(cronExpressionField);
         } catch (Exception ignore) {
         } // never happens
     }    


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1700 - “A field should not duplicate the name of its class”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1700
Please let me know if you have any questions.
Ayman Abdelghany.