### PR TITLE
Upgrade hsqldb version dependency to 2.3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
 			<dependency>
 				<groupId>org.hsqldb</groupId>
 				<artifactId>hsqldb</artifactId>
-				<version>2.3.3</version>
+				<version>2.3.4</version>
 			</dependency>
 			<dependency>
 				<groupId>com.h2database</groupId>


### PR DESCRIPTION
In the following environment

ArchLinux 4.4.5-1
Java openjdk version "1.8.0_74" 64-Bit Server VM (build 25.74-b02, mixed mode)

we have got the following error while code compilation 

test(net.sf.hajdbc.sql.BlobTest)  Time elapsed: 0.283 sec  <<< ERROR!
java.sql.SQLException: lob is no longer valid
    at net.sf.hajdbc.sql.BlobTest.test(BlobTest.java:72)
Caused by: org.hsqldb.HsqlException: lob is no longer valid
    at net.sf.hajdbc.sql.BlobTest.test(BlobTest.java:72)

HSQLDB version upgrade to 2.3.4 should solve the problem
