### PR TITLE
Update AbstractInvocationHandler.java

### DIFF
--- a/core/src/main/java/net/sf/hajdbc/sql/AbstractInvocationHandler.java
+++ b/core/src/main/java/net/sf/hajdbc/sql/AbstractInvocationHandler.java
@@ -223,12 +223,12 @@ public class AbstractInvocationHandler<Z, D extends Database<Z>, T, E extends Ex
 			
 			if (factory.differs(primaryResult, result))
 			{
-				results.remove();
 				D database = entry.getKey();
+				results.remove();
 				
 				if (cluster.deactivate(database, cluster.getStateManager()))
 				{
-					this.logger.log(Level.ERROR, this.messages.inconsistent(cluster, database, primaryResult, result));
+					this.logger.log(Level.ERROR, this.messages.inconsistent(cluster, database, result, primaryResult));
 				}
 			}
 		}


### PR DESCRIPTION
Two bugs fix:
1.  The underlying data structure for the resultsMap is a TreeMap which is a red-black tree.  Removing an entry from the iterator affects the key and value referenced in the entry object.  See https://stackoverflow.com/questions/7488571/treemap-iterator-behaviour-not-consistent-upon-removal for more info.
With this bug, if you have 3 databases in sync, remove an entry from db2, update the same entry in db1, db3 gets deactivated instead of db2!!!

2.  The error message mixes up the results for the primary database and the offending database.

Please review @pferraro 